### PR TITLE
feat: add initial swiftui app skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "MacUninstallerApp",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(name: "MacUninstallerApp", targets: ["MacUninstallerApp"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "MacUninstallerApp",
+            path: "Sources",
+            resources: []
+        ),
+        .testTarget(
+            name: "MacUninstallerAppTests",
+            dependencies: ["MacUninstallerApp"],
+            path: "Tests"
+        )
+    ]
+)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var finder = AppFinder()
+    
+    var body: some View {
+        AppListView(apps: finder.apps)
+            .onAppear {
+                finder.loadApps()
+            }
+            .frame(minWidth: 400, minHeight: 300)
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/Sources/MacUninstallerApp.swift
+++ b/Sources/MacUninstallerApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct MacUninstallerApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Sources/Models/AppEntry.swift
+++ b/Sources/Models/AppEntry.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct AppEntry: Identifiable {
+    let id = UUID()
+    let name: String
+    let path: String
+}

--- a/Sources/Services/AppFinder.swift
+++ b/Sources/Services/AppFinder.swift
@@ -1,0 +1,22 @@
+import Foundation
+import SwiftUI
+
+class AppFinder: ObservableObject {
+    @Published var apps: [AppEntry] = []
+    
+    func loadApps() {
+        let applicationPaths = ["/Applications", "\(NSHomeDirectory())/Applications"]
+        var found: [AppEntry] = []
+        for path in applicationPaths {
+            guard let contents = try? FileManager.default.contentsOfDirectory(atPath: path) else { continue }
+            for item in contents where item.hasSuffix(".app") {
+                let fullPath = (path as NSString).appendingPathComponent(item)
+                let entry = AppEntry(name: item.replacingOccurrences(of: ".app", with: ""), path: fullPath)
+                found.append(entry)
+            }
+        }
+        DispatchQueue.main.async {
+            self.apps = found.sorted { $0.name < $1.name }
+        }
+    }
+}

--- a/Sources/Services/AppUninstaller.swift
+++ b/Sources/Services/AppUninstaller.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct AppUninstaller {
+    func uninstall(app: AppEntry) throws {
+        let url = URL(fileURLWithPath: app.path)
+        try FileManager.default.trashItem(at: url, resultingItemURL: nil)
+        // TODO: remove related Library, Caches, Preferences
+    }
+}

--- a/Sources/Views/AppListView.swift
+++ b/Sources/Views/AppListView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct AppListView: View {
+    let apps: [AppEntry]
+    
+    var body: some View {
+        List(apps) { app in
+            HStack {
+                Text(app.name)
+                Spacer()
+                Text(app.path)
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+}
+
+struct AppListView_Previews: PreviewProvider {
+    static var previews: some View {
+        AppListView(apps: [])
+    }
+}

--- a/Tests/AppFinderTests.swift
+++ b/Tests/AppFinderTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import MacUninstallerApp
+
+final class AppFinderTests: XCTestCase {
+    func testLoadAppsDoesNotThrow() async {
+        let finder = AppFinder()
+        finder.loadApps()
+        XCTAssertTrue(true) // placeholder assertion
+    }
+}


### PR DESCRIPTION
## Summary
- create Swift executable package for `MacUninstallerApp`
- add SwiftUI entry point and content view
- list installed apps from `/Applications` and `~/Applications`
- stub out app uninstaller service
- add minimal unit test target

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68845e21a1408333baf7ebc3f0c60a92