### PR TITLE
docs: add build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ git clone https://github.com/your-org/mac-uninstaller.git
 open mac-uninstaller.xcodeproj
 ```
 
+Once the project opens in Xcode you can run the application with `Cmd + R` and
+execute the unit tests using `Cmd + U`.
+
+### 🚀 Build & Package
+
+1. In Xcode choose **Product -> Archive** to produce a release build.
+2. Install [`create-dmg`](https://github.com/create-dmg/create-dmg) via Homebrew:
+   `brew install create-dmg`.
+3. Generate a distributable `.dmg`:
+
+   ```bash
+   create-dmg "build/MacUninstaller.app"
+   ```
+
+The resulting disk image can be shared with users on macOS 13 or later.
+
 ### 🧪 Tests
 
 ```bash


### PR DESCRIPTION
## Summary
- document how to run the project from Xcode
- explain steps for generating a `.dmg` release

## Testing
- `swift test --disable-sandbox` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_688496f806888333aa6c5a7d3974e344